### PR TITLE
Add option to pre-load modules on first query

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ const map = {
     },
     Subscription: {},
   },
+  //
+  // Allow force pre-loading certain modules on first query
+  //   preloadModules: [0, 1]
 };
 
 const link = createIncrementalSchemaLink({

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,10 @@ interface Dependencies {
   [moduleIndex: string]: number[] | undefined;
 }
 
+type ModuleList = number[];
+
 type SchemaModuleMapInternal = {
+  preloadModules?: ModuleList;
   modules?: SchemaModuleLoader[];
   dependencies?: Dependencies;
   sharedModule: SchemaModuleLoader;
@@ -170,7 +173,7 @@ function SchemaModulesManager({
   contextBuilder,
   schemaDefinition,
 }: IncrementalSchemaLinkOptions) {
-  let usedModules: number[] = [];
+  let usedModules: number[] = map.preloadModules || [];
 
   /**
    * Collects a list of required modules (based on root-level fields)


### PR DESCRIPTION
Sometimes there is a performance reason to have some modules pre-load on first query, to avoid waterfalls of module loading.